### PR TITLE
Add plugin.yml and bungee.yml for BungeeCord

### DIFF
--- a/test/content/bungeecord/bungee.yml
+++ b/test/content/bungeecord/bungee.yml
@@ -11,3 +11,4 @@ main: "example.ExamplePlugin"
 mc-publish:
   modrinth: "AAAA"
   curseforge: 123456
+  loaders: ["bungeecord", "waterfall"]

--- a/test/content/bungeecord/bungee.yml
+++ b/test/content/bungeecord/bungee.yml
@@ -1,0 +1,13 @@
+name: "ExamplePlugin" # Automatically acts as ID too
+version: "1.0.0"
+description: "Description"
+authors: ["author"] # There is also "author" that accepts a single String
+
+depends: ["RequiredPlugin"] # Required dependencies
+softDepends: ["OptionalPlugin"] # Optional dependencies
+
+main: "example.ExamplePlugin"
+
+mc-publish:
+  modrinth: "AAAA"
+  curseforge: 123456

--- a/test/content/bungeecord/plugin.yml
+++ b/test/content/bungeecord/plugin.yml
@@ -1,0 +1,14 @@
+name: "ExamplePlugin" # Automatically acts as ID too
+version: "1.0.0"
+description: "Description"
+authors: ["author"] # There is also "author" that accepts a single String
+
+depends: ["RequiredPlugin"] # Required dependencies
+softDepends: ["OptionalPlugin"] # Optional dependencies
+
+main: "example.ExamplePlugin"
+
+mc-publish:
+  modrinth: "AAAA"
+  curseforge: 123456
+  loaders: ["bungeecord", "waterfall"]


### PR DESCRIPTION
Adds a `plugin.yml` and `bungee.yml` for BungeeCord in `tests/content/bungeecord/`

- BungeeCord plugins do not have a separate ID, but use the `name` as ID instead.
- There is no system to define dependencies of the following type:
   - Embedded/Included
   - Conflicting
   - Breaking
   - Incompatible
- There is no system to define a custom metadata for dependencies

The file has been tested and is considered valid by BungeeCord/Waterfall (As mentioned in #23 does BungeeCord ignore any unknown options)