### PR TITLE
Add plugin.yml for Bukkit, Spigot, Paper and Purpur

### DIFF
--- a/test/content/spigot/plugin.yml
+++ b/test/content/spigot/plugin.yml
@@ -1,0 +1,14 @@
+name: "ExamplePlugin" # Automatically acts as ID too
+version: "1.0.0"
+description: "Description"
+authors: ["author"] # There is also "author" that accepts a single String
+
+depends: ["RequiredPlugin"] # Required dependencies
+softDepends: ["OptionalPlugin"] # Optional dependencies
+
+main: "example.ExamplePlugin"
+
+mc-publish:
+  modrinth: "AAAA"
+  curseforge: 123456
+  loaders: ["bukkit", "spigot", "paper", "purpur"]


### PR DESCRIPTION
Adds a `plugin.yml` for Bukkit, Spigot, Paper and Purpur in `tests/content/spigot/`

- Spigot plugins do not have a separate ID, but use the `name` as ID instead.
- There is no system to define dependencies of the following type:
   - Embedded/Included (Unless the `libraries` option, which downloads dependencies from MavenCentral is counted)
   - Conflicting
   - Breaking
   - Incompatible
- There is no system to define custom metadata for dependencies

The file has been tested on Paper and is considered valid by it (Since Paper nor Purpur do modifications of the plugin.yml is the file also valid on Spigot and Bukkit)