### PR TITLE
Add velocity-plugin.json for Velocity

### DIFF
--- a/test/content/velocity/velocity-plugin.json
+++ b/test/content/velocity/velocity-plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "exampleplugin",
+  "name": "ExamplePlugin",
+  "version": "1.0.0",
+  "description": "Description",
+  "authors": [
+    "author"
+  ],
+  "dependencies": [
+    {
+      "id": "optional",
+      "optional": true
+    },
+    {
+      "id": "required",
+      "optional": false
+    }
+  ],
+  "main": "example.ExamplePlugin",
+  "mc-publish": {
+    "modrinth": "AAAA"
+    "curseforge": 123456
+  }
+}


### PR DESCRIPTION
Adds a `velocity-plugin.json` for Velocity in `tests/content/velocity/`

- There is no system to define dependencies of the following type:
   - Embedded/Included
   - Conflicting
   - Breaking
   - Incompatible
- There is no system to define custom metadata for dependencies

The file has been tested on Velocity and is considered valid by it.