### PR TITLE
Add user agent to mc-publish, as required by the API terms for Modrinth

### DIFF
--- a/src/utils/modrinth/index.ts
+++ b/src/utils/modrinth/index.ts
@@ -39,6 +39,7 @@ export function createVersion(modId: string, data: Record<string, any>, files: F
         method: "POST",
         headers: form.getHeaders({
             Authorization: token,
+            "User-Agent": "mc-publish (+https://github.com/Kir-Antipov/mc-publish)"
         }),
         body: <any>form
     });
@@ -74,6 +75,7 @@ export async function modifyVersion(id: string, version: Partial<ModrinthVersion
         headers: {
             "Authorization": token,
             "Content-Type": "application/json",
+            "User-Agent": "mc-publish (+https://github.com/Kir-Antipov/mc-publish)"
         },
         body: JSON.stringify(version)
     });


### PR DESCRIPTION
It will also get blocked by Cloudflare if it has no user agent header. This causes problems as shown https://canary.discord.com/channels/734077874708938864/783153806531100673/1092126127360852049 (requires you to be in https://discord.gg/modrinth-734077874708938864)