### PR TITLE
Add sponge_plugins.json for Sponge

### DIFF
--- a/tests/content/sponge/sponge_plugins.json
+++ b/tests/content/sponge/sponge_plugins.json
@@ -1,0 +1,63 @@
+{
+    "loader": {
+        "name": "java_plain",
+        "version": "1.0"
+    },
+    "license": "MIT",
+    "global": {
+        "version": "8.0.0",
+        "links": {},
+        "branding": {},
+        "contributors": [
+            {
+                "name": "Name",
+                "description": "Author"
+            }
+        ],
+        "dependencies": [
+            {
+                "id": "spongeapi",
+                "version": "8.1.0",
+                "load-order": "after",
+                "optional": false
+            }
+        ]
+    },
+    "plugins": [
+        {
+            "id": "exampleplugin",
+            "entrypoint": "example.ExamplePlugin",
+            "name": "ExamplePlugin",
+            "description": "Description",
+            "version": "1.0.0",
+            "branding": {},
+            "links": {},
+            "contributors": [
+                {
+                    "name": "Name",
+                    "description": "Author"
+                }
+            ],
+            "dependencies": [
+                {
+                    "id": "spongeapi",
+                    "version": "8.1.0",
+                    "load-order": "after",
+                    "optional": false
+                },
+                {
+                    "id": "required",
+                    "version": "1.0.0",
+                    "load-order": "after",
+                    "optional": false
+                },
+                {
+                    "id": "optional",
+                    "version": "1.0.0",
+                    "load-order": "after",
+                    "optional": true
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds `sponge_plugins.json` for Sponge (#23). Note this is included in the `/META-INF/` directory in plugin jarfile and, in most cases, generated by the sponge gradle plugin or annotations. This file has been tested and passes with Sponge API v8.1.0. v7 and lower accept a different format entirely (mcmod.toml iirc)

Sponge is quite strict with parsing these files, so it's not possible to add custom mc-publish metadata fields. Even if it was, it wouldn't really be helpful due to the way these files are generated for the vast majority of sponge users.

* There is no system to define custom metadata
* Dependencies:
  * There is no way of defining custom dependency metadata
  * Embedded/Included, Conflicting, Breaking and Incompatible dependencies cannot be defined (only required/optional)
* Only `sponge` is accepted as the supported loader.
* Sponge plugins can bundle multiple plugins in one jarfile. Parameters set in the `global` field apply to each plugin in the `plugins` field and plugins can provide their own overriding parameters. The `id`, `name`, `description` and `entrypoint` parameters cannot be set in the `global` field and must be set for each plugin in `plugins`. At least one plugin is required in the `plugins` field for it to be valid. Thus, you can grab the name and ID from the first plugin in the `plugins` array.

(this PR supercedes #34)