### PR TITLE
Replace `mock-fs` with `memfs`

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -14,4 +14,7 @@ module.exports = {
         "^@/(.*)$": "<rootDir>/src/$1",
     },
     transformIgnorePatterns: [],
+    setupFilesAfterEnv: [
+        "./tests/setup-memfs.ts",
+    ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,22 +18,21 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.23.8",
+        "@types/adm-zip": "^0.5.5",
         "@types/jest": "^29.5.11",
-        "@types/mock-fs": "^4.13.4",
         "@types/node": "^16.18.31",
         "@types/node-fetch": "^2.6.10",
         "@types/semver": "^7.5.6",
-        "@types/yazl": "^2.4.5",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
         "@vercel/ncc": "^0.38.1",
+        "adm-zip": "^0.5.16",
         "babel-jest": "^29.7.0",
         "eslint": "^8.56.0",
         "jest": "^29.7.0",
-        "mock-fs": "^5.2.0",
+        "memfs": "^4.13.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.3.3",
-        "yazl": "^2.5.1"
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2656,6 +2655,63 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsonjoy.com/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.1.0.tgz",
+      "integrity": "sha512-zlQONA+msXPPwHWZMKFVS78ewFczIll5lXiVPwFPCZUsrOKdxc2AvxU1HoNBmMRhqDZUR9HkC3UOm+6pME6Xsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "^1.1.1",
+        "@jsonjoy.com/util": "^1.1.2",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^1.20.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.5.0.tgz",
+      "integrity": "sha512-ojoNsrIuPI9g6o8UxhraZQSyF2ByJanAY4cTFbc8Mf2AXEF4aQRGY1dJxyJpuyav8r9FGflEt/Ff3u5Nt6YMPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2710,6 +2766,16 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.5.tgz",
+      "integrity": "sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2802,15 +2868,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-    "node_modules/@types/mock-fs": {
-      "version": "4.13.4",
-      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.4.tgz",
-      "integrity": "sha512-mXmM0o6lULPI8z3XNnQCpL0BGxPwx1Ul1wXYEPBGl4efShyxW2Rln0JOPEWGyZaYZMM6OVXM/15zUuFMY52ljg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "16.18.70",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
@@ -2853,15 +2910,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
-    },
-    "node_modules/@types/yazl": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-2.4.5.tgz",
-      "integrity": "sha512-qpmPfx32HS7vlGJf7EsoM9qJnLZhXJBf1KH0hzfdc+D794rljQWh4H0I/UrZy+6Nhqn0l2jdBZXBGZtR1vnHqw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.18.1",
@@ -3111,6 +3159,16 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {
@@ -3489,15 +3547,6 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -4664,6 +4713,16 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
       }
     },
     "node_modules/ignore": {
@@ -6656,6 +6715,26 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/memfs": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.13.0.tgz",
+      "integrity": "sha512-dIs5KGy24fbdDhIAg0RxXpFqQp3RwL6wgSMRF9OSuphL/Uc9a4u2/SDJKPLj/zUgtOGKuHrRMrj563+IErj4Cg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/json-pack": "^1.0.3",
+        "@jsonjoy.com/util": "^1.3.0",
+        "tree-dump": "^1.0.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6722,15 +6801,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/mock-fs": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.2.0.tgz",
-      "integrity": "sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/ms": {
@@ -7529,6 +7599,19 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/thingies": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
+      "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -7559,6 +7642,23 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+    },
+    "node_modules/tree-dump": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
+      "integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -7614,6 +7714,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7903,15 +8010,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3"
       }
     },
     "node_modules/yocto-queue": {
@@ -9794,6 +9892,32 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@jsonjoy.com/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@jsonjoy.com/json-pack": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.1.0.tgz",
+      "integrity": "sha512-zlQONA+msXPPwHWZMKFVS78ewFczIll5lXiVPwFPCZUsrOKdxc2AvxU1HoNBmMRhqDZUR9HkC3UOm+6pME6Xsg==",
+      "dev": true,
+      "requires": {
+        "@jsonjoy.com/base64": "^1.1.1",
+        "@jsonjoy.com/util": "^1.1.2",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^1.20.0"
+      }
+    },
+    "@jsonjoy.com/util": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.5.0.tgz",
+      "integrity": "sha512-ojoNsrIuPI9g6o8UxhraZQSyF2ByJanAY4cTFbc8Mf2AXEF4aQRGY1dJxyJpuyav8r9FGflEt/Ff3u5Nt6YMPA==",
+      "dev": true,
+      "requires": {}
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -9839,6 +9963,15 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "@types/adm-zip": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.5.tgz",
+      "integrity": "sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/babel__core": {
@@ -9931,15 +10064,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-    "@types/mock-fs": {
-      "version": "4.13.4",
-      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.4.tgz",
-      "integrity": "sha512-mXmM0o6lULPI8z3XNnQCpL0BGxPwx1Ul1wXYEPBGl4efShyxW2Rln0JOPEWGyZaYZMM6OVXM/15zUuFMY52ljg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "16.18.70",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
@@ -9982,15 +10106,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
-    },
-    "@types/yazl": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-2.4.5.tgz",
-      "integrity": "sha512-qpmPfx32HS7vlGJf7EsoM9qJnLZhXJBf1KH0hzfdc+D794rljQWh4H0I/UrZy+6Nhqn0l2jdBZXBGZtR1vnHqw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "6.18.1",
@@ -10137,6 +10252,12 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -10417,12 +10538,6 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
-    },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -11258,6 +11373,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true
+    },
+    "hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
       "dev": true
     },
     "ignore": {
@@ -12748,6 +12869,18 @@
         "tmpl": "1.0.5"
       }
     },
+    "memfs": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.13.0.tgz",
+      "integrity": "sha512-dIs5KGy24fbdDhIAg0RxXpFqQp3RwL6wgSMRF9OSuphL/Uc9a4u2/SDJKPLj/zUgtOGKuHrRMrj563+IErj4Cg==",
+      "dev": true,
+      "requires": {
+        "@jsonjoy.com/json-pack": "^1.0.3",
+        "@jsonjoy.com/util": "^1.3.0",
+        "tree-dump": "^1.0.1",
+        "tslib": "^2.0.0"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -12797,12 +12930,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "mock-fs": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.2.0.tgz",
-      "integrity": "sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -13361,6 +13488,13 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "thingies": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
+      "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+      "dev": true,
+      "requires": {}
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -13386,6 +13520,13 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
+    "tree-dump": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
+      "integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
+      "dev": true,
+      "requires": {}
+    },
     "ts-api-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -13408,6 +13549,12 @@
         "semver": "^7.5.3",
         "yargs-parser": "^21.0.1"
       }
+    },
+    "tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -13607,15 +13754,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
-    },
-    "yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3"
-      }
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -35,22 +35,21 @@
   "homepage": "https://github.com/Kir-Antipov/mc-publish#readme",
   "devDependencies": {
     "@babel/preset-env": "^7.23.8",
+    "@types/adm-zip": "^0.5.5",
     "@types/jest": "^29.5.11",
-    "@types/mock-fs": "^4.13.4",
     "@types/node": "^16.18.31",
     "@types/node-fetch": "^2.6.10",
     "@types/semver": "^7.5.6",
-    "@types/yazl": "^2.4.5",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",
     "@vercel/ncc": "^0.38.1",
+    "adm-zip": "^0.5.16",
     "babel-jest": "^29.7.0",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
-    "mock-fs": "^5.2.0",
+    "memfs": "^4.13.0",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.3.3",
-    "yazl": "^2.5.1"
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "fast-glob": "^3.3.2",

--- a/tests/setup-memfs.ts
+++ b/tests/setup-memfs.ts
@@ -1,0 +1,6 @@
+import { fs } from "memfs";
+
+jest.mock("node:fs", () => fs);
+jest.mock("node:fs/promises", () => fs.promises);
+jest.mock("fs", () => fs);
+jest.mock("fs/promises", () => fs.promises);

--- a/tests/unit/games/minecraft/minecraft-version.spec.ts
+++ b/tests/unit/games/minecraft/minecraft-version.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { actualFs } from "@/../tests/utils/actual-fs";
 import { resolve } from "node:path";
 import { parseVersion } from "@/utils/versioning/version";
 import { VersionType } from "@/utils/versioning/version-type";
@@ -87,7 +87,7 @@ describe("MinecraftVersion", () => {
 
 describe("getMinecraftVersionManifestEntries", () => {
     const manifest : MinecraftVersionManifest = JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/mojang/version_manifest_v2.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/mojang/version_manifest_v2.json"), "utf8")
     );
 
     test("returns correct number of entries", () => {

--- a/tests/unit/loaders/fabric/fabric-metadata-reader.spec.ts
+++ b/tests/unit/loaders/fabric/fabric-metadata-reader.spec.ts
@@ -1,17 +1,13 @@
 import { zipFile } from "@/../tests/utils/zip-utils";
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { FabricMetadata } from "@/loaders/fabric/fabric-metadata";
 import { FabricMetadataReader } from "@/loaders/fabric/fabric-metadata-reader";
 
-beforeEach(async () => {
-    mockFs({
-        "fabric.mod.jar": await zipFile([__dirname, "../../../content/fabric/fabric.mod.json"]),
+beforeEach(() => {
+    vol.fromJSON({
+        "fabric.mod.jar": zipFile([__dirname, "../../../content/fabric/fabric.mod.json"]),
         "text.txt": "",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("FabricMetadataReader", () => {

--- a/tests/unit/loaders/fabric/fabric-metadata.spec.ts
+++ b/tests/unit/loaders/fabric/fabric-metadata.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { actualFs } from "@/../tests/utils/actual-fs";
 import { resolve as resolvePath } from "node:path";
 import { DependencyType } from "@/dependencies/dependency-type";
 import { PlatformType } from "@/platforms/platform-type";
@@ -6,7 +6,7 @@ import { RawFabricMetadata } from "@/loaders/fabric/raw-fabric-metadata";
 import { FabricMetadata } from "@/loaders/fabric/fabric-metadata";
 
 const RAW_METADATA: RawFabricMetadata = Object.freeze(JSON.parse(
-    readFileSync(resolvePath(__dirname, "../../../content/fabric/fabric.mod.json"), "utf8")
+    actualFs.readFileSync(resolvePath(__dirname, "../../../content/fabric/fabric.mod.json"), "utf8")
 ));
 
 describe("FabricMetadata", () => {

--- a/tests/unit/loaders/forge/forge-metadata-reader.spec.ts
+++ b/tests/unit/loaders/forge/forge-metadata-reader.spec.ts
@@ -1,17 +1,13 @@
 import { zipFile } from "@/../tests/utils/zip-utils";
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { ForgeMetadata } from "@/loaders/forge/forge-metadata";
 import { ForgeMetadataReader } from "@/loaders/forge/forge-metadata-reader";
 
-beforeEach(async () => {
-    mockFs({
-        "forge.mod.jar": await zipFile([__dirname, "../../../content/forge/mods.toml"], "META-INF/mods.toml"),
+beforeEach(() => {
+    vol.fromJSON({
+        "forge.mod.jar": zipFile([__dirname, "../../../content/forge/mods.toml"], "META-INF/mods.toml"),
         "text.txt": "",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("ForgeMetadataReader", () => {

--- a/tests/unit/loaders/forge/forge-metadata.spec.ts
+++ b/tests/unit/loaders/forge/forge-metadata.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { actualFs } from "@/../tests/utils/actual-fs";
 import { resolve as resolvePath } from "node:path";
 import { parse as parseToml } from "toml";
 import { DependencyType } from "@/dependencies/dependency-type";
@@ -7,7 +7,7 @@ import { RawForgeMetadata } from "@/loaders/forge/raw-forge-metadata";
 import { ForgeMetadata } from "@/loaders/forge/forge-metadata";
 
 const RAW_METADATA: RawForgeMetadata = Object.freeze(parseToml(
-    readFileSync(resolvePath(__dirname, "../../../content/forge/mods.toml"), "utf8")
+    actualFs.readFileSync(resolvePath(__dirname, "../../../content/forge/mods.toml"), "utf8")
 ));
 
 describe("ForgeMetadata", () => {

--- a/tests/unit/loaders/loader-metadata-reader.spec.ts
+++ b/tests/unit/loaders/loader-metadata-reader.spec.ts
@@ -1,6 +1,6 @@
 import { zipFile } from "@/../tests/utils/zip-utils";
 import { LoaderType } from "@/loaders/loader-type";
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import {
     LoaderMetadataReader,
     combineLoaderMetadataReaders,
@@ -8,19 +8,15 @@ import {
     createDefaultLoaderMetadataReader,
 } from "@/loaders/loader-metadata-reader";
 
-beforeEach(async () => {
-    mockFs({
-        "fabric.jar": await zipFile([__dirname, "../../content/fabric/fabric.mod.json"]),
-        "quilt.jar": await zipFile([__dirname, "../../content/quilt/quilt.mod.json"]),
-        "forge.jar": await zipFile([__dirname, "../../content/forge/mods.toml"], "META-INF/mods.toml"),
-        "neoforge.jar": await zipFile([__dirname, "../../content/neoforge/neoforge.mods.toml"], "META-INF/neoforge.mods.toml"),
-        "neoforge.legacy.jar": await zipFile([__dirname, "../../content/neoforge/neoforge.mods.toml"], "META-INF/mods.toml"),
+beforeEach(() => {
+    vol.fromJSON({
+        "fabric.jar": zipFile([__dirname, "../../content/fabric/fabric.mod.json"]),
+        "quilt.jar": zipFile([__dirname, "../../content/quilt/quilt.mod.json"]),
+        "forge.jar": zipFile([__dirname, "../../content/forge/mods.toml"], "META-INF/mods.toml"),
+        "neoforge.jar": zipFile([__dirname, "../../content/neoforge/neoforge.mods.toml"], "META-INF/neoforge.mods.toml"),
+        "neoforge.legacy.jar": zipFile([__dirname, "../../content/neoforge/neoforge.mods.toml"], "META-INF/mods.toml"),
         "text.txt": "",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("combineLoaderMetadataReaders", () => {

--- a/tests/unit/loaders/neoforge/neoforge-metadata-reader.spec.ts
+++ b/tests/unit/loaders/neoforge/neoforge-metadata-reader.spec.ts
@@ -1,17 +1,13 @@
 import { zipFile } from "@/../tests/utils/zip-utils";
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { NeoForgeMetadata } from "@/loaders/neoforge/neoforge-metadata";
 import { NeoForgeMetadataReader } from "@/loaders/neoforge/neoforge-metadata-reader";
 
-beforeEach(async () => {
-    mockFs({
-        "neoforge.mod.jar": await zipFile([__dirname, "../../../content/neoforge/neoforge.mods.toml"], "META-INF/neoforge.mods.toml"),
+beforeEach(() => {
+    vol.fromJSON({
+        "neoforge.mod.jar": zipFile([__dirname, "../../../content/neoforge/neoforge.mods.toml"], "META-INF/neoforge.mods.toml"),
         "text.txt": "",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("NeoForgeMetadataReader", () => {

--- a/tests/unit/loaders/neoforge/neoforge-metadata.spec.ts
+++ b/tests/unit/loaders/neoforge/neoforge-metadata.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { actualFs } from "@/../tests/utils/actual-fs";
 import { resolve as resolvePath } from "node:path";
 import { parse as parseToml } from "toml";
 import { DependencyType } from "@/dependencies/dependency-type";
@@ -7,7 +7,7 @@ import { RawNeoForgeMetadata } from "@/loaders/neoforge/raw-neoforge-metadata";
 import { NeoForgeMetadata } from "@/loaders/neoforge/neoforge-metadata";
 
 const RAW_METADATA: RawNeoForgeMetadata = Object.freeze(parseToml(
-    readFileSync(resolvePath(__dirname, "../../../content/neoforge/neoforge.mods.toml"), "utf8")
+    actualFs.readFileSync(resolvePath(__dirname, "../../../content/neoforge/neoforge.mods.toml"), "utf8")
 ));
 
 describe("NeoForgeMetadata", () => {

--- a/tests/unit/loaders/quilt/quilt-metadata-reader.spec.ts
+++ b/tests/unit/loaders/quilt/quilt-metadata-reader.spec.ts
@@ -1,17 +1,13 @@
 import { zipFile } from "@/../tests/utils/zip-utils";
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { QuiltMetadata } from "@/loaders/quilt/quilt-metadata";
 import { QuiltMetadataReader } from "@/loaders/quilt/quilt-metadata-reader";
 
-beforeEach(async () => {
-    mockFs({
-        "quilt.mod.jar": await zipFile([__dirname, "../../../content/quilt/quilt.mod.json"]),
+beforeEach(() => {
+    vol.fromJSON({
+        "quilt.mod.jar": zipFile([__dirname, "../../../content/quilt/quilt.mod.json"]),
         "text.txt": "",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("QuiltMetadataReader", () => {

--- a/tests/unit/loaders/quilt/quilt-metadata.spec.ts
+++ b/tests/unit/loaders/quilt/quilt-metadata.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { actualFs } from "@/../tests/utils/actual-fs";
 import { resolve as resolvePath } from "node:path";
 import { DependencyType } from "@/dependencies/dependency-type";
 import { PlatformType } from "@/platforms/platform-type";
@@ -6,7 +6,7 @@ import { RawQuiltMetadata } from "@/loaders/quilt/raw-quilt-metadata";
 import { QuiltMetadata } from "@/loaders/quilt/quilt-metadata";
 
 const RAW_METADATA: RawQuiltMetadata = Object.freeze(JSON.parse(
-    readFileSync(resolvePath(__dirname, "../../../content/quilt/quilt.mod.json"), "utf8")
+    actualFs.readFileSync(resolvePath(__dirname, "../../../content/quilt/quilt.mod.json"), "utf8")
 ));
 
 describe("QuiltMetadata", () => {

--- a/tests/unit/platforms/curseforge/curseforge-game-version-map.spec.ts
+++ b/tests/unit/platforms/curseforge/curseforge-game-version-map.spec.ts
@@ -1,13 +1,13 @@
 import { resolve } from "node:path";
-import { readFile } from "node:fs/promises";
+import { actualFsPromises } from "@/../tests/utils/actual-fs";
 import { BUKKIT_GAME_VERSION_TYPE } from "@/platforms/curseforge/curseforge-game-version-type";
 import { createCurseForgeGameVersionMap } from "@/platforms/curseforge/curseforge-game-version-map";
 
 describe("createCurseForgeGameVersionMap", () => {
     test("organizes the provided versions into their respective buckets", async () => {
         const [versionsSource, versionTypesSource] = await Promise.all([
-            readFile(resolve(__dirname, "../../../content/curseforge/versions.json"), "utf8"),
-            readFile(resolve(__dirname, "../../../content/curseforge/version-types.json"), "utf8"),
+            actualFsPromises.readFile(resolve(__dirname, "../../../content/curseforge/versions.json"), "utf8"),
+            actualFsPromises.readFile(resolve(__dirname, "../../../content/curseforge/version-types.json"), "utf8"),
         ]);
         const versions = JSON.parse(versionsSource);
         const versionTypes = [...JSON.parse(versionTypesSource), BUKKIT_GAME_VERSION_TYPE];

--- a/tests/unit/platforms/curseforge/curseforge-upload-api-client.spec.ts
+++ b/tests/unit/platforms/curseforge/curseforge-upload-api-client.spec.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
+import { actualFs } from "@/../tests/utils/actual-fs";
 import { resolve } from "node:path";
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { createFakeFetch } from "../../../utils/fetch-utils";
 import { FormData } from "@/utils/net/form-data";
 import { HttpResponse } from "@/utils/net/http-response";
@@ -16,11 +16,11 @@ const FILES = Object.freeze([
 
 const DB = Object.freeze({
     versionTypes: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/curseforge/version-types.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/curseforge/version-types.json"), "utf8")
     )),
 
     versions: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/curseforge/versions.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/curseforge/versions.json"), "utf8")
     )),
 
     projects: Object.freeze([
@@ -157,11 +157,7 @@ const CURSEFORGE_FETCH = createFakeFetch({
 beforeEach(() => {
     const fakeFiles = FILES.reduce((a, b) => ({ ...a, [b]: "" }), {});
 
-    mockFs(fakeFiles);
-});
-
-afterEach(() => {
-    mockFs.restore();
+    vol.fromJSON(fakeFiles);
 });
 
 describe("CurseForgeUploadApiClient", () => {

--- a/tests/unit/platforms/curseforge/curseforge-uploader.spec.ts
+++ b/tests/unit/platforms/curseforge/curseforge-uploader.spec.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
+import { actualFs } from "@/../tests/utils/actual-fs";
 import { resolve } from "node:path";
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { createCombinedFetch, createFakeFetch } from "../../../utils/fetch-utils";
 import { PlatformType } from "@/platforms/platform-type";
 import { SecureString } from "@/utils/security/secure-string";
@@ -17,11 +17,11 @@ import { CurseForgeUploader } from "@/platforms/curseforge/curseforge-uploader";
 
 const DB = Object.freeze({
     versionTypes: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/curseforge/version-types.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/curseforge/version-types.json"), "utf8")
     )),
 
     versions: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/curseforge/versions.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/curseforge/versions.json"), "utf8")
     )),
 });
 
@@ -96,13 +96,9 @@ const CURSEFORGE_FETCH = createCombinedFetch(
 );
 
 beforeEach(() => {
-    mockFs({
+    vol.fromJSON({
         "file.txt": "",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("CurseForgeUploader", () => {

--- a/tests/unit/platforms/github/github-api-client.spec.ts
+++ b/tests/unit/platforms/github/github-api-client.spec.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs";
+import { actualFs } from "@/../tests/utils/actual-fs";
 import { resolve } from "node:path";
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { createFakeFetch } from "../../../utils/fetch-utils";
 import { HttpResponse } from "@/utils/net/http-response";
 import { GitHubRelease, GitHubReleaseInit, GitHubReleasePatch } from "@/platforms/github/github-release";
@@ -8,7 +8,7 @@ import { GITHUB_API_URL, GitHubApiClient } from "@/platforms/github/github-api-c
 
 const DB = Object.freeze({
     releases: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/github/releases.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/github/releases.json"), "utf8")
     )) as GitHubRelease[],
 });
 
@@ -120,11 +120,7 @@ beforeEach(() => {
     const fileNames = DB.releases.flatMap(x => x.assets).map(x => x.name);
     const fakeFiles = fileNames.reduce((a, b) => ({ ...a, [b]: "" }), {});
 
-    mockFs(fakeFiles);
-});
-
-afterEach(() => {
-    mockFs.restore();
+    vol.fromJSON(fakeFiles);
 });
 
 describe("GitHubApiClient", () => {

--- a/tests/unit/platforms/github/github-context.spec.ts
+++ b/tests/unit/platforms/github/github-context.spec.ts
@@ -1,4 +1,4 @@
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { GitHubContext } from "@/platforms/github/github-context";
 
 describe("GitHubContext", () => {
@@ -74,13 +74,9 @@ describe("GitHubContext", () => {
 
     describe("payload", () => {
         beforeAll(() => {
-            mockFs({
+            vol.fromJSON({
                 "payload.json": JSON.stringify({ release: { id: 42 } }),
             });
-        });
-
-        afterAll(() => {
-            mockFs.restore();
         });
 
         test("returns payload when GITHUB_EVENT_PATH is set and file exists", () => {

--- a/tests/unit/platforms/github/github-uploader.spec.ts
+++ b/tests/unit/platforms/github/github-uploader.spec.ts
@@ -1,4 +1,4 @@
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { createFakeFetch } from "../../../utils/fetch-utils";
 import { PlatformType } from "@/platforms/platform-type";
 import { SecureString } from "@/utils/security/secure-string";
@@ -63,13 +63,9 @@ const CONTEXT = new GitHubContext({
 });
 
 beforeEach(() => {
-    mockFs({
+    vol.fromJSON({
         "file.txt": "",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("GitHubUploader", () => {

--- a/tests/unit/platforms/modrinth/modrinth-api-client.spec.ts
+++ b/tests/unit/platforms/modrinth/modrinth-api-client.spec.ts
@@ -1,5 +1,5 @@
-import mockFs from "mock-fs";
-import { readFileSync } from "node:fs";
+import { vol } from "memfs";
+import { actualFs } from "@/../tests/utils/actual-fs";
 import { resolve } from "node:path";
 import { createFakeFetch } from "../../../utils/fetch-utils";
 import { FormData } from "@/utils/net/form-data";
@@ -13,19 +13,19 @@ import { MODRINTH_API_URL, ModrinthApiClient } from "@/platforms/modrinth/modrin
 
 const DB = Object.freeze({
     loaders: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/modrinth/loader.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/modrinth/loader.json"), "utf8")
     )) as ModrinthLoader[],
 
     gameVersions: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/modrinth/game_version.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/modrinth/game_version.json"), "utf8")
     )) as ModrinthGameVersion[],
 
     projects: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/modrinth/projects.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/modrinth/projects.json"), "utf8")
     )) as ModrinthProject[],
 
     versions: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/modrinth/versions.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/modrinth/versions.json"), "utf8")
     )) as ModrinthVersion[],
 });
 
@@ -196,11 +196,7 @@ beforeEach(() => {
     const fileNames = DB.versions.flatMap(x => x.files).map(x => x.filename);
     const fakeFiles = fileNames.reduce((a, b) => ({ ...a, [b]: "" }), {});
 
-    mockFs(fakeFiles);
-});
-
-afterEach(() => {
-    mockFs.restore();
+    vol.fromJSON(fakeFiles);
 });
 
 describe("ModrinthApiClient", () => {

--- a/tests/unit/platforms/modrinth/modrinth-uploader.spec.ts
+++ b/tests/unit/platforms/modrinth/modrinth-uploader.spec.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
-import { readFileSync } from "node:fs";
-import mockFs from "mock-fs";
+import { actualFs } from "@/../tests/utils/actual-fs";
+import { vol } from "memfs";
 import { createFakeFetch } from "../../../utils/fetch-utils";
 import { SecureString } from "@/utils/security/secure-string";
 import { PlatformType } from "@/platforms/platform-type";
@@ -17,11 +17,11 @@ import { ModrinthUploader } from "@/platforms/modrinth/modrinth-uploader";
 
 const DB = Object.freeze({
     loaders: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/modrinth/loader.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/modrinth/loader.json"), "utf8")
     )),
 
     gameVersions: Object.freeze(JSON.parse(
-        readFileSync(resolve(__dirname, "../../../content/modrinth/game_version.json"), "utf8")
+        actualFs.readFileSync(resolve(__dirname, "../../../content/modrinth/game_version.json"), "utf8")
     )),
 });
 
@@ -80,13 +80,9 @@ const MODRINTH_FETCH = createFakeFetch({
 });
 
 beforeEach(() => {
-    mockFs({
+    vol.fromJSON({
         "file.txt": "",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("ModrinthUploader", () => {

--- a/tests/unit/utils/actions/action-metadata.spec.ts
+++ b/tests/unit/utils/actions/action-metadata.spec.ts
@@ -1,8 +1,8 @@
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { parseActionMetadataFromFile, parseActionMetadataFromString } from "@/utils/actions/action-metadata";
 
 beforeEach(() => {
-    mockFs({
+    vol.fromJSON({
         "action.yml": `
             name: Test Action
             description: This is a test action
@@ -15,10 +15,6 @@ beforeEach(() => {
                 type: number
         `,
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("parseActionMetadataFromString", () => {

--- a/tests/unit/utils/actions/action-output.spec.ts
+++ b/tests/unit/utils/actions/action-output.spec.ts
@@ -1,4 +1,4 @@
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { readFile } from "node:fs/promises";
 import { ActionMetadata } from "@/utils/actions/action-metadata";
 import { ActionParameterPathParser } from "@/utils/actions/action-parameter-path-parser";
@@ -9,13 +9,9 @@ const ENV = Object.freeze({
 });
 
 beforeEach(() => {
-    mockFs({
+    vol.fromJSON({
         "output.txt": "",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("setActionOutput", () => {

--- a/tests/unit/utils/errors/file-not-found-error.spec.ts
+++ b/tests/unit/utils/errors/file-not-found-error.spec.ts
@@ -1,5 +1,5 @@
 import { FileNotFoundError } from "@/utils/errors/file-not-found-error";
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 
 describe("FileNotFoundError", () => {
     describe("constructor", () => {
@@ -24,11 +24,7 @@ describe("FileNotFoundError", () => {
 
     describe("throwIfNotFound", () => {
         beforeEach(() => {
-            mockFs({ test: "test" });
-        });
-
-        afterEach(() => {
-            mockFs.restore();
+            vol.fromJSON({ test: "test" });
         });
 
         test("throws error if file does not exist", () => {

--- a/tests/unit/utils/io/file-info.spec.ts
+++ b/tests/unit/utils/io/file-info.spec.ts
@@ -1,5 +1,4 @@
-import { statSync } from "node:fs";
-import mockFs from "mock-fs";
+import { fs as memfs, vol } from "memfs";
 import { zipContent } from "../../../utils/zip-utils";
 import {
     FileInfo,
@@ -14,18 +13,14 @@ import {
     readZippedFile,
 } from "@/utils/io/file-info";
 
-beforeEach(async () => {
-    mockFs({
+beforeEach(() => {
+    vol.fromNestedJSON({
         "path/to": {
             "test.txt": "test",
             "test.json": JSON.stringify({ foo: 42 }),
-            "test.zip": await zipContent("test", "test.txt"),
+            "test.zip": zipContent("test", "test.txt"),
         },
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("FileInfo", () => {
@@ -95,7 +90,7 @@ describe("FileInfo", () => {
         test("returns the file size", () => {
             const info = new FileInfo("path/to/test.txt");
 
-            expect(info.size).toBe(statSync("path/to/test.txt").size);
+            expect(info.size).toBe(memfs.statSync("path/to/test.txt").size);
         });
 
         test("throws if the file does not exist", () => {

--- a/tests/unit/utils/net/blob.spec.ts
+++ b/tests/unit/utils/net/blob.spec.ts
@@ -1,14 +1,10 @@
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { Blob, isBlob, readBlob, readBlobSync } from "@/utils/net/blob";
 
 beforeEach(() => {
-    mockFs({
+    vol.fromJSON({
         "test.txt": "test",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("isBlob", () => {

--- a/tests/unit/utils/net/form-data.spec.ts
+++ b/tests/unit/utils/net/form-data.spec.ts
@@ -1,16 +1,12 @@
-import mockFs from "mock-fs";
+import { vol } from "memfs";
 import { FileInfo } from "@/utils/io/file-info";
 import { FILE_PATH, FormData, isFormData, toFormData } from "@/utils/net/form-data";
 import { isBlob } from "@/utils/net/blob";
 
 beforeEach(() => {
-    mockFs({
+    vol.fromJSON({
         "file.json": "{}",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("FormData", () => {

--- a/tests/unit/utils/net/headers.spec.ts
+++ b/tests/unit/utils/net/headers.spec.ts
@@ -1,17 +1,12 @@
-import { createReadStream, statSync } from "node:fs";
-import mockFs from "mock-fs";
+import { fs as memfs, vol } from "memfs";
 import { ArrayMap, MultiMap } from "@/utils/collections/map";
 import { Blob } from "@/utils/net/blob";
 import { appendHeader, appendHeaders, cloneHeaders, deleteHeader, deleteHeaders, getHeader, hasHeader, inferHttpRequestBodyHeaders, setDefaultHeader, setDefaultHeaders, setHeader, setHeaders } from "@/utils/net";
 
 beforeEach(() => {
-    mockFs({
+    vol.fromJSON({
         "file.json": "{}",
     });
-});
-
-afterEach(() => {
-    mockFs.restore();
 });
 
 describe("hasHeader", () => {
@@ -575,11 +570,11 @@ describe("inferHttpRequestBodyHeaders", () => {
     });
 
     test("returns correct headers when body is a ReadableStream created from a file path", () => {
-        const body = createReadStream("file.json");
+        const body = memfs.createReadStream("file.json");
 
         const headers = inferHttpRequestBodyHeaders(body);
 
         expect(headers["Content-Type"]).toBe("application/octet-stream");
-        expect(headers["Content-Length"]).toBe(String(statSync("file.json").size));
+        expect(headers["Content-Length"]).toBe(String(memfs.statSync("file.json").size));
     });
 });

--- a/tests/utils/actual-fs.ts
+++ b/tests/utils/actual-fs.ts
@@ -1,0 +1,2 @@
+export const actualFs = jest.requireActual<typeof import("node:fs")>("node:fs");
+export const actualFsPromises = jest.requireActual<typeof import("node:fs/promises")>("node:fs/promises");

--- a/tests/utils/fetch-utils.ts
+++ b/tests/utils/fetch-utils.ts
@@ -1,5 +1,4 @@
-import { readFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { actualFs, actualFsPromises } from "./actual-fs";
 import { resolve } from "node:path";
 import { Fetch, HttpMethod, HttpRequest, HttpResponse, createFetch } from "@/utils/net";
 
@@ -32,8 +31,8 @@ async function normalizeResponse(response: FetchInterceptorResponse): Promise<Ht
 
     if (Array.isArray(response) && response.length && response.every(x => typeof x === "string")) {
         const path = resolve(...response);
-        if (existsSync(path)) {
-            const content = await readFile(path, "utf8");
+        if (actualFs.existsSync(path)) {
+            const content = await actualFsPromises.readFile(path, "utf8");
             return HttpResponse.text(content);
         }
     }

--- a/tests/utils/zip-utils.ts
+++ b/tests/utils/zip-utils.ts
@@ -1,31 +1,18 @@
 import { basename, resolve as resolvePath } from "node:path";
-import { ZipFile } from "yazl";
+import Zip from "adm-zip";
 
-export async function zipFile(path: string | string[], zipPath?: string): Promise<Buffer> {
+export function zipFile(path: string | string[], zipPath?: string): Buffer {
+    const fs = jest.requireActual<typeof import("node:fs")>("node:fs");
     const realPath = typeof path === "string" ? path : resolvePath(...path);
     zipPath ||= basename(realPath);
 
-    const zip = new ZipFile();
-    zip.addFile(realPath, zipPath);
-    zip.end();
-
-    const chunks = [] as Buffer[];
-    for await (const chunk of zip.outputStream) {
-        chunks.push(Buffer.from(chunk));
-    }
-
-    return Buffer.concat(chunks);
+    const zip = new Zip();
+    zip.addFile(zipPath, fs.readFileSync(realPath));
+    return zip.toBuffer();
 }
 
-export async function zipContent(content: string | Buffer, zipPath: string): Promise<Buffer> {
-    const zip = new ZipFile();
-    zip.addBuffer(Buffer.from(content), zipPath);
-    zip.end();
-
-    const chunks = [] as Buffer[];
-    for await (const chunk of zip.outputStream) {
-        chunks.push(Buffer.from(chunk));
-    }
-
-    return Buffer.concat(chunks);
+export function zipContent(content: string | Buffer, zipPath: string): Buffer {
+    const zip = new Zip();
+    zip.addFile(zipPath, typeof content === "string" ? Buffer.from(content) : content);
+    return zip.toBuffer();
 }


### PR DESCRIPTION
<!-- See CONTRIBUTING.md for general guidelines on contributions. -->
<!-- Don't forget to target your pull request exclusively against the `dev` branch. -->

## Description
`mock-fs` doesn't work on NodeJS 20, use `memfs` instead.
https://github.com/streamich/memfs

All tests passed in NodeJS 22.9.0.

<!-- What does the pull request do? -->
<!-- Provide background on the PR, including links to related issues, etc. -->
## Implementation Notes
- mock `fs` `fs/promises` in all tests
  - use [tests/utils/actual-fs](https://github.com/Kir-Antipov/mc-publish/pull/129/files#diff-d369b897d43152f455961c6602bf72734c6c6d78aef45262fd01b102b4f9de6b) when the original `fs` is needed, such as loading test data
- removed `yazl`, use `adm-zip`
  - `yazl` was used to create a dummy zip file, but the tests timed out, so it was replaced with `adm-zip`, which has a synchronous method available.

<!-- How was the solution implemented (if it's not obvious)? -->
<!-- Include any information that might be useful to a reviewer here, if any. Otherwise, delete this section. -->

## Checklist

 - [x] Added unit tests for every exported function/class.
 - [x] Added JSDoc to every public function/class/class member.
 - [x] Added relevant information to the README.
