### PR TITLE
Autofix: [Bug] No retry on Piston server

### DIFF
--- a/src/games/minecraft/mojang-api-client.ts
+++ b/src/games/minecraft/mojang-api-client.ts
@@ -3,6 +3,8 @@ import { VersionRange, parseVersion } from "@/utils/versioning";
 import { $i } from "@/utils/collections";
 import { MinecraftVersion, MinecraftVersionManifest, getMinecraftVersionManifestEntries } from "./minecraft-version";
 import { getMinecraftVersionRegExp, normalizeMinecraftVersion, normalizeMinecraftVersionRange } from "./minecraft-version-lookup";
+import { retry } from "@/utils/async-utils";
+import { getDefaultLogger } from "@/utils/logging";
 
 /**
  * The default base URL for the Mojang API.
@@ -101,8 +103,7 @@ export class MojangApiClient {
             return this._versions;
         }
 
-        const response = await this._fetch("/game/version_manifest_v2.json");
-        const manifest = await response.json<MinecraftVersionManifest>();
+        const manifest = await this.fetchVersionManifest();
         const manifestEntries = getMinecraftVersionManifestEntries(manifest);
 
         const versions = manifestEntries.map((entry, i, self) => {
@@ -113,6 +114,29 @@ export class MojangApiClient {
 
         this._versions = new Map(versions.map(x => [x.id, x]));
         return this._versions;
+    }
+
+    /**
+     * Fetches the Minecraft version manifest with retry logic.
+     *
+     * @returns A promise that resolves to the MinecraftVersionManifest.
+     */
+    private async fetchVersionManifest(): Promise<MinecraftVersionManifest> {
+        const logger = getDefaultLogger();
+        return await retry(
+            async () => {
+                const response = await this._fetch("/game/version_manifest_v2.json");
+                return await response.json<MinecraftVersionManifest>();
+            },
+            {
+                maxAttempts: 3,
+                delay: 1000,
+                onError: (error) => {
+                    logger.warn(`Failed to fetch Minecraft version manifest. Retrying... Error: ${error.message}`);
+                    return true;
+                },
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
I have implemented a retry mechanism for the MojangApiClient to handle potential issues with Mojang's metadata server. This solution adds retry logic to the `getAllMinecraftVersions` method, which is the core method for fetching Minecraft version data.

Here's a summary of the changes:

1. I've imported the `retry` function from `@/utils/async-utils`.
2. I've added a new private method `fetchVersionManifest` that encapsulates the fetching logic with retry mechanism.
3. I've updated the `getAllMinecraftVersions` method to use the new `fetchVersionManifest` method.
4. The retry logic will attempt to fetch the version manifest up to 3 times, with a 1-second delay between attempts.
5. I've also added error logging using the default logger.

These changes should make the MojangApiClient more resilient to temporary server issues while maintaining its current functionality. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
> 
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
